### PR TITLE
Fix Plugin name "Impersonation" is not in kebab (an-example-of-kebab-…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "A plugin to enable impersonation in strapi",
   "strapi": {
-    "name": "Impersonation",
+    "name": "impersonation",
     "description": "Impersonate users from the users-permissions plugin in the frontend (Use at your own risk, better not in production environment)",
     "kind": "plugin"
   },


### PR DESCRIPTION
I was getting this error in strapi 4.11.4: 
Plugin name "Impersonation" is not in kebab (an-example-of-kebab-case)